### PR TITLE
add solarized colors files

### DIFF
--- a/colors/doom-solarized-flat.vim
+++ b/colors/doom-solarized-flat.vim
@@ -1,0 +1,1 @@
+lua require('doom-solarized.solarized-flat.highlights')

--- a/colors/doom-solarized-high.vim
+++ b/colors/doom-solarized-high.vim
@@ -1,0 +1,1 @@
+lua require('doom-solarized.solarized-high.highlights')

--- a/colors/doom-solarized-low.vim
+++ b/colors/doom-solarized-low.vim
@@ -1,0 +1,1 @@
+lua require('doom-solarized.solarized-low.highlights')

--- a/colors/doom-solarized.vim
+++ b/colors/doom-solarized.vim
@@ -1,0 +1,1 @@
+lua require('doom-solarized.solarized-normal.highlights')


### PR DESCRIPTION
Resolves https://github.com/NTBBloodbath/doom-nvim/issues/205.

These changes adds colors files to load all the missing colors. Looks like only the `solarized` colors didn't have colors files.